### PR TITLE
docs: Update README to point to graphql-config v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ GraphQL extension VSCode built with the aim to tightly integrate the [GraphQL Ec
 1. [Install watchman](https://facebook.github.io/watchman/docs/install.html).
 2. Install the [VSCode GraphQL Extension](https://marketplace.visualstudio.com/items?itemName=Prisma.vscode-graphql).
 
-**This extension requires a valid `.graphqlconfig` or `.graphqlconfig.yml` file in the project root.** You can read more about that [here](https://github.com/prismagraphql/graphql-config).
+**This extension requires a valid `.graphqlconfig` or `.graphqlconfig.yml` file in the project root.** You can read more about that [here](https://github.com/kamilkisiela/graphql-config/tree/legacy#graphql-config).
 
 To support language features like "go-to definition" across multiple files, please include `includes` key in the graphql-config per project. For example,
 


### PR DESCRIPTION
The linked GraphQL config repository points at the latest version 3 of the spec, but this plugin implements a previous version. This makes that version clear.