### PR TITLE
feat: add restart option to vscode-graphql command pallate

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,12 +106,12 @@
         "title": "VSCode GraphQL - Is Debugging?"
       },
       {
-        "command": "extension.contentProvider",
-        "title": "Execute GraphQL Operations"
-      },
-      {
         "command": "extension.restart",
         "title": "VSCode GraphQL - Restart"
+      },
+      {
+        "command": "extension.contentProvider",
+        "title": "Execute GraphQL Operations"
       }
     ],
     "typescriptServerPlugins": [

--- a/package.json
+++ b/package.json
@@ -108,6 +108,10 @@
       {
         "command": "extension.contentProvider",
         "title": "Execute GraphQL Operations"
+      },
+      {
+        "command": "extension.restart",
+        "title": "VSCode GraphQL - Restart"
       }
     ],
     "typescriptServerPlugins": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -168,6 +168,11 @@ export async function activate(context: ExtensionContext) {
     },
   )
   context.subscriptions.push(commandContentProvider)
+
+  commands.registerCommand("extension.restart", async () => {
+    await client.stop()
+    await client.start()
+  })
 }
 
 export function deactivate() {


### PR DESCRIPTION
As a small workaround for [Does not work when updating the schema](https://github.com/prisma-labs/vscode-graphql/issues/104) and from this [suggestion](https://github.com/prisma-labs/vscode-graphql/issues/104#issuecomment-642311198):

This PR proposes a command to restart the gql plugin.  So, instead of restarting vs-code, a user can do ctrl-shift-p to pull up the Command Palette and type something like "graphql restart".

It's not great, but as the cantiero indicates, "Beats restarting the editor for sure".

