### PR TITLE
fix: be sure to register directive def at source scope in grammar

### DIFF
--- a/grammars/graphql.json
+++ b/grammars/graphql.json
@@ -10,6 +10,7 @@
         { "include": "#graphql-description-docstring" },
         { "include": "#graphql-description-singleline" },
         { "include": "#graphql-fragment-definition" },
+        { "include": "#graphql-directive-definition" },
         { "include": "#graphql-type-interface" },
         { "include": "#graphql-enum" },
         { "include": "#graphql-scalar" },


### PR DESCRIPTION
in #183 we forgot this!

Before, we had just fixed inline argument comments for directive definitions and other types with inline arguments, but we had not solved the top-level keyword/etc definition issue. graphql 15 Directive definitions before #183 were still almost all green, unhighlighted!

Before (after #183):
![image](https://user-images.githubusercontent.com/1368727/89740592-1905a900-da58-11ea-9150-25b97543a7ba.png)

After:
![image](https://user-images.githubusercontent.com/1368727/89740574-ef4c8200-da57-11ea-8709-c8287a83a181.png)
