### PR TITLE
fix: Downgrade graphql config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Test
+
+on: pull_request
+
+jobs:
+ compile:
+    name: Compile and check peer dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: npm install
+      - name: Compile
+        run: npm run compile
+      - name: Check peer dependencies
+        run: npm list --production --parseable --depth=99999 --loglevel=error

--- a/package-lock.json
+++ b/package-lock.json
@@ -197,6 +197,27 @@
           "requires": {
             "iterall": "1.1.3"
           }
+        },
+        "graphql-config": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-2.2.2.tgz",
+          "integrity": "sha512-mtv1ejPyyR2mJUUZNhljggU+B/Xl8tJJWf+h145hB+1Y48acSghFalhNtXfPBcYl2tJzpb+lGxfj3O7OjaiMgw==",
+          "requires": {
+            "graphql-import": "^0.7.1",
+            "graphql-request": "^1.5.0",
+            "js-yaml": "^3.10.0",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.4"
+          }
+        },
+        "graphql-import": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/graphql-import/-/graphql-import-0.7.1.tgz",
+          "integrity": "sha512-YpwpaPjRUVlw2SN3OPljpWbVRWAhMAyfSba5U47qGMOSsPLi2gYeJtngGpymjm9nk57RFWEpjqwh4+dpYuFAPw==",
+          "requires": {
+            "lodash": "^4.17.4",
+            "resolve-from": "^4.0.0"
+          }
         }
       }
     },
@@ -918,9 +939,12 @@
       "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
     },
     "graphql": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.0.0.tgz",
-      "integrity": "sha512-ZyVO1xIF9F+4cxfkdhOJINM+51B06Friuv4M66W7HzUOeFd+vNzUn4vtswYINPi6sysjf1M2Ri/rwZALqgwbaQ=="
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.12.3.tgz",
+      "integrity": "sha512-Hn9rdu4zacplKXNrLCvR8YFiTGnbM4Zw/UH8FDmzBDsH7ou40lSNH4tIlsxcYnz2TGNVJCpu1WxCM23yd6kzhA==",
+      "requires": {
+        "iterall": "1.1.3"
+      }
     },
     "graphql-config": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "babel-polyfill": "6.26.0",
     "capitalize": "1.0.0",
     "dotenv": "6.2.0",
-    "graphql": "15.0.x",
+    "graphql": "0.12.x",
     "graphql-config": "2.2.2",
     "graphql-config-extension-prisma": "0.3.0",
     "graphql-language-service-server": "2.3.3",


### PR DESCRIPTION
Since commit https://github.com/prisma-labs/vscode-graphql/commit/bb93c44cc856318ce8c113940872bfe7deef1132#diff-b9cfc7f2cdf78a7f4b91a753d10865a2 the CI has been failing silently because of peer dependency issues. Therefore downgrading to `0.12.x` for dep `graphql` .

cc @acao 

![dep](https://user-images.githubusercontent.com/30771368/89996775-85b4b980-dc8b-11ea-91e5-5e37928375bd.png)
