### PR TITLE
chore: bump gls server for improvements, add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,46 @@
 # Change Log
-All notable changes to the "vscode-graphql" extension will be documented in this file.
+
+All notable changes to the "vscode-graphql" extension will be manually documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [Unreleased]
-- Initial release
+The git log should show a fairly clean view of each of these new versions, and the issues/PRs associated.
+
+# 0.3.7
+
+- update underlying `graphql-language-service-server` to allow .gql, .graphqls extensions
+
+# 0.3.6
+
+- documentation fix
+
+# 0.3.5
+
+- readme documentation improvements, more examples, FAQ, known issues
+- bump `graphql-language-service-server` to allow implicit fragment completion (non-inline fragments). just include your fragments file or string in the graphql-config `documents`
+
+# 0.3.4
+
+- remove insiders announcement until tooling is properly in place, and insiders extension is up to date
+
+# 0.3.3
+
+- `useSchemaFileDefinition` setting
+
+# 0.3.2
+
+- #213: bugfix for input validation on operation exection
+
+# 0.3.1 🎉
+
+- upgrade to `graphql-config@3`
+- upgrade to latest major version of `graphql-language-service-server`
+  - upgrades `graphql-config@3`
+  - remove watchman dependency 🎉
+  - introduce workspace symbol lookup, outline
+  - validation and completion for input variables
+  - generate a schema output by default, for code-first schemas. SDL first schemas have an override option now
+
+## Historical 0.2.x versions
+
+[todo]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1119,9 +1119,9 @@
       }
     },
     "graphql-language-service-server": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/graphql-language-service-server/-/graphql-language-service-server-2.5.0.tgz",
-      "integrity": "sha512-c7b/o/B0C9oGY1SdIi0DA9hayI3BJuOHrf/Jxc3HDE/RDJJ37yYTVcngW03yNHBoS0LhAJvjJ8RhVnA1f+r1rg==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-server/-/graphql-language-service-server-2.5.2.tgz",
+      "integrity": "sha512-oZNLHBAhMlkFi/x697eMSq5y+WJB1p5u3WhAS6P+fBGusZiydpSKefLy0KXz4A4ym52jtM4llIankWSjRW+iNA==",
       "requires": {
         "@babel/parser": "^7.9.0",
         "glob": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "dotenv": "^8.2.0",
     "graphql": "^15.3.0",
     "graphql-config": "^3.0.3",
-    "graphql-language-service-server": "^2.5.0",
+    "graphql-language-service-server": "^2.5.2",
     "graphql-tag": "^2.11.0",
     "node-fetch": "^2.6.0",
     "ovsx": "0.1.0-next.dacd2fd",


### PR DESCRIPTION
just manually track the changelog for now, with a general summary

Solves #219 
also solves #218 where `.gql` extension was not working